### PR TITLE
Fix: Add missing package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "ffmpeg-converter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ffmpeg-converter",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ffmpeg-converter",
+  "version": "1.0.0",
+  "description": "Premiere Pro panel for FFmpeg conversion",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
The build was failing because the Node.js CI workflow expects a package-lock.json file to run 'npm ci'. This change adds a minimal package.json and the corresponding package-lock.json to satisfy the build process.

The project does not have any explicit npm dependencies, but these files are required for the CI to pass.